### PR TITLE
fix: linux strerror compatibility

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -10,6 +10,7 @@ export ZOPEN_EXTRA_CONFIGURE_OPTS="--disable-dependency-tracking"
 export ZOPEN_CHECK_TIMEOUT=30000 # 8 hours and a bit
 export PERL="/bin/env perl"
 export ZOPEN_COMP=CLANG
+export ZOSLIB_ERROR_COMPAT=""
 
 zopen_check_results()
 {

--- a/buildenv
+++ b/buildenv
@@ -3,7 +3,7 @@ COREUTILS_VERSION="9.7"
 
 export ZOPEN_BUILD_LINE="STABLE"
 export ZOPEN_STABLE_URL="https://ftp.gnu.org/gnu/coreutils/coreutils-${COREUTILS_VERSION}.tar.gz"
-export ZOPEN_STABLE_DEPS="make gzip tar curl perl automake autoconf m4 sed gettext zoslib diffutils findutils getopt"
+export ZOPEN_STABLE_DEPS="make gzip tar curl perl automake autoconf m4 sed gettext zoslib diffutils findutils getopt gawk"
 export ZOPEN_BOOTSTRAP="skip"
 export ZOPEN_EXTRA_CPPFLAGS="-DSLOW_BUT_NO_HACKS=1 -DNO_ASM -D_LARGE_TIME_API"
 export ZOPEN_EXTRA_CONFIGURE_OPTS="--disable-dependency-tracking"


### PR DESCRIPTION
improve test case coverage by removing EDC* prefix and period suffix from error messages. Improvement should be around +30-ish extra test cases pass (newest version of zoslib zopen2 branch needed)