### PR TITLE
Enable UTF8 locales by default

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -3,10 +3,9 @@ COREUTILS_VERSION="9.7"
 
 export ZOPEN_BUILD_LINE="STABLE"
 export ZOPEN_STABLE_URL="https://ftp.gnu.org/gnu/coreutils/coreutils-${COREUTILS_VERSION}.tar.gz"
-export ZOPEN_STABLE_DEPS="make gzip tar curl perl automake autoconf m4 sed gettext zoslib diffutils findutils getopt gawk"
+export ZOPEN_STABLE_DEPS="make gzip tar curl perl automake autoconf m4 sed gettext zoslib diffutils findutils getopt gawk libiconv"
 export ZOPEN_BOOTSTRAP="skip"
 export ZOPEN_EXTRA_CPPFLAGS="-DSLOW_BUT_NO_HACKS=1 -DNO_ASM -D_LARGE_TIME_API"
-export ZOPEN_EXTRA_CONFIGURE_OPTS="--disable-dependency-tracking"
 export ZOPEN_CHECK_TIMEOUT=30000 # 8 hours and a bit
 export PERL="/bin/env perl"
 export ZOPEN_COMP=CLANG

--- a/stable-patches/lib/localcharset.c.patch
+++ b/stable-patches/lib/localcharset.c.patch
@@ -1,0 +1,22 @@
+diff --git i/lib/localcharset.c w/lib/localcharset.c
+index 32f6f78..210e3e7 100644
+--- i/lib/localcharset.c
++++ w/lib/localcharset.c
+@@ -1063,7 +1063,7 @@ locale_charset (void)
+         /* Did not find it in the table.  */
+         /* On Mac OS X, all modern locales use the UTF-8 encoding.
+            BeOS and Haiku have a single locale, and it has UTF-8 encoding.  */
+-# if (defined __APPLE__ && defined __MACH__) || defined __BEOS__ || defined __HAIKU__
++# if (defined __APPLE__ && defined __MACH__) || defined __BEOS__ || defined __HAIKU__ || defined(__MVS__)
+         codeset = "UTF-8";
+ # else
+         /* Don't return an empty string.  GNU libc and GNU libiconv interpret
+@@ -1136,7 +1136,7 @@ locale_charset (void)
+         /* Did not find it in the table.  */
+         /* On Mac OS X, all modern locales use the UTF-8 encoding.
+            BeOS and Haiku have a single locale, and it has UTF-8 encoding.  */
+-# if (defined __APPLE__ && defined __MACH__) || defined __BEOS__ || defined __HAIKU__
++# if (defined __APPLE__ && defined __MACH__) || defined __BEOS__ || defined __HAIKU__ || defined(__MVS__)
+         codeset = "UTF-8";
+ # else
+         /* The canonical name cannot be determined.  */


### PR DESCRIPTION
This enables UTF8 locales by default similar to other platforms.

This enables the translation to UTF-8 based languages:

```
 LANG=ja_JP.UTF-8 gls --help
使用法: gls [オプション]... [ファイル]...
FILE (デフォルトは現在のディレクトリ) に関する情報を一覧表示します。
-cftuvSUX のいずれも指定されず、 --sort も指定されていない場合、
要素はアルファベット順でソートされます。

長いオプションで必須となっている引数は短いオプションでも必須です。
```

The above also requires a change to support relocable locales from gettext and this is pending